### PR TITLE
feat: add `equals` & `hashCode` to variants without payloads

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "github-actions.workflows.pinned.workflows": [
+        ".github/workflows/test.yml"
+    ]
+}

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:    gotyno-hs
-version: 1.2.11
+version: 1.2.12
 synopsis: A type definition compiler supporting multiple output languages.
 description: Compiles type definitions into F#, TypeScript and Python, with validators, decoders and encoders.
 license: BSD2

--- a/test/reference-output/basic.kt
+++ b/test/reference-output/basic.kt
@@ -34,15 +34,29 @@ data class Recruiter(
 sealed class GetSearchesFilter : java.io.Serializable {
     @Serializable
     @JsonTypeName("SearchesByQueryLike")
-    data class SearchesByQueryLike(val data: String) : GetSearchesFilter(), java.io.Serializable {val type = "SearchesByQueryLike"}
+    data class SearchesByQueryLike(val data: String) : GetSearchesFilter(), java.io.Serializable {
+        val type = "SearchesByQueryLike"
+    }
 
     @Serializable
     @JsonTypeName("SearchesByResultLike")
-    data class SearchesByResultLike(val data: String) : GetSearchesFilter(), java.io.Serializable {val type = "SearchesByResultLike"}
+    data class SearchesByResultLike(val data: String) : GetSearchesFilter(), java.io.Serializable {
+        val type = "SearchesByResultLike"
+    }
 
     @Serializable
     @JsonTypeName("NoSearchesFilter")
-    class NoSearchesFilter : GetSearchesFilter(), java.io.Serializable {val type = "NoSearchesFilter"}
+    class NoSearchesFilter : GetSearchesFilter(), java.io.Serializable {
+        val type = "NoSearchesFilter"
+
+        override fun equals(other: Any?): Boolean {
+            return other is NoSearchesFilter
+        }
+
+        override fun hashCode(): Int {
+            return 0
+        }
+    }
 }
 
 @Serializable
@@ -98,19 +112,27 @@ data class Email(
 sealed class Event : java.io.Serializable {
     @Serializable
     @JsonTypeName("LogIn")
-    data class LogIn(val data: LogInData) : Event(), java.io.Serializable {val type = "LogIn"}
+    data class LogIn(val data: LogInData) : Event(), java.io.Serializable {
+        val type = "LogIn"
+    }
 
     @Serializable
     @JsonTypeName("LogOut")
-    data class LogOut(val data: UserId) : Event(), java.io.Serializable {val type = "LogOut"}
+    data class LogOut(val data: UserId) : Event(), java.io.Serializable {
+        val type = "LogOut"
+    }
 
     @Serializable
     @JsonTypeName("JoinChannels")
-    data class JoinChannels(val data: ArrayList<Channel>) : Event(), java.io.Serializable {val type = "JoinChannels"}
+    data class JoinChannels(val data: ArrayList<Channel>) : Event(), java.io.Serializable {
+        val type = "JoinChannels"
+    }
 
     @Serializable
     @JsonTypeName("SetEmails")
-    data class SetEmails(val data: ArrayList<Email>) : Event(), java.io.Serializable {val type = "SetEmails"}
+    data class SetEmails(val data: ArrayList<Email>) : Event(), java.io.Serializable {
+        val type = "SetEmails"
+    }
 }
 
 @Serializable
@@ -122,11 +144,23 @@ sealed class Event : java.io.Serializable {
 sealed class Maybe<T> : java.io.Serializable {
     @Serializable
     @JsonTypeName("Nothing")
-    class Nothing<T> : Maybe<T>(), java.io.Serializable {val type = "Nothing"}
+    class Nothing<T> : Maybe<T>(), java.io.Serializable {
+        val type = "Nothing"
+
+        override fun equals(other: Any?): Boolean {
+            return other is Nothing<*>
+        }
+
+        override fun hashCode(): Int {
+            return 0
+        }
+    }
 
     @Serializable
     @JsonTypeName("Just")
-    data class Just<T>(val data: T) : Maybe<T>(), java.io.Serializable {val type = "Just"}
+    data class Just<T>(val data: T) : Maybe<T>(), java.io.Serializable {
+        val type = "Just"
+    }
 }
 
 @Serializable
@@ -138,11 +172,15 @@ sealed class Maybe<T> : java.io.Serializable {
 sealed class Either<L, R> : java.io.Serializable {
     @Serializable
     @JsonTypeName("Left")
-    data class Left<L, R>(val data: L) : Either<L, R>(), java.io.Serializable {val type = "Left"}
+    data class Left<L, R>(val data: L) : Either<L, R>(), java.io.Serializable {
+        val type = "Left"
+    }
 
     @Serializable
     @JsonTypeName("Right")
-    data class Right<L, R>(val data: R) : Either<L, R>(), java.io.Serializable {val type = "Right"}
+    data class Right<L, R>(val data: R) : Either<L, R>(), java.io.Serializable {
+        val type = "Right"
+    }
 }
 
 @Serializable
@@ -174,10 +212,22 @@ data class Person(
 sealed class EmbeddedEvent : java.io.Serializable {
     @Serializable
     @JsonTypeName("EmbeddedLogIn")
-    data class EmbeddedLogIn(@JsonValue(true) val data: LogInData) : EmbeddedEvent(), java.io.Serializable {val type = "EmbeddedLogIn"}
+    data class EmbeddedLogIn(@JsonValue(true) val data: LogInData) : EmbeddedEvent(), java.io.Serializable {
+        val type = "EmbeddedLogIn"
+    }
 
     @Serializable
     @JsonTypeName("SystemImploded")
-    class SystemImploded : EmbeddedEvent(), java.io.Serializable {val type = "SystemImploded"}
+    class SystemImploded : EmbeddedEvent(), java.io.Serializable {
+        val type = "SystemImploded"
+
+        override fun equals(other: Any?): Boolean {
+            return other is SystemImploded
+        }
+
+        override fun hashCode(): Int {
+            return 0
+        }
+    }
 }
 }

--- a/test/reference-output/generics.kt
+++ b/test/reference-output/generics.kt
@@ -131,11 +131,15 @@ data class KnownForShowWithoutTypeTag(
 sealed class KnownForEmbedded : java.io.Serializable {
     @Serializable
     @JsonTypeName("movieStartingWithLowercase")
-    data class MovieStartingWithLowercase(@JsonValue(true) val data: KnownForMovieWithoutTypeTag) : KnownForEmbedded(), java.io.Serializable {val media_type = "movieStartingWithLowercase"}
+    data class MovieStartingWithLowercase(@JsonValue(true) val data: KnownForMovieWithoutTypeTag) : KnownForEmbedded(), java.io.Serializable {
+        val media_type = "movieStartingWithLowercase"
+    }
 
     @Serializable
     @JsonTypeName("tvStartingWithLowercase")
-    data class TvStartingWithLowercase(@JsonValue(true) val data: KnownForShowWithoutTypeTag) : KnownForEmbedded(), java.io.Serializable {val media_type = "tvStartingWithLowercase"}
+    data class TvStartingWithLowercase(@JsonValue(true) val data: KnownForShowWithoutTypeTag) : KnownForEmbedded(), java.io.Serializable {
+        val media_type = "tvStartingWithLowercase"
+    }
 }
 
 @Serializable
@@ -147,10 +151,14 @@ sealed class KnownForEmbedded : java.io.Serializable {
 sealed class KnownForEmbeddedWithUpperCase : java.io.Serializable {
     @Serializable
     @JsonTypeName("Movie")
-    data class Movie(@JsonValue(true) val data: KnownForMovieWithoutTypeTag) : KnownForEmbeddedWithUpperCase(), java.io.Serializable {val media_type = "Movie"}
+    data class Movie(@JsonValue(true) val data: KnownForMovieWithoutTypeTag) : KnownForEmbeddedWithUpperCase(), java.io.Serializable {
+        val media_type = "Movie"
+    }
 
     @Serializable
     @JsonTypeName("Tv")
-    data class Tv(@JsonValue(true) val data: KnownForShowWithoutTypeTag) : KnownForEmbeddedWithUpperCase(), java.io.Serializable {val media_type = "Tv"}
+    data class Tv(@JsonValue(true) val data: KnownForShowWithoutTypeTag) : KnownForEmbeddedWithUpperCase(), java.io.Serializable {
+        val media_type = "Tv"
+    }
 }
 }

--- a/test/reference-output/github.kt
+++ b/test/reference-output/github.kt
@@ -94,11 +94,15 @@ data class OrganizationData(
 sealed class Owner : java.io.Serializable {
     @Serializable
     @JsonTypeName("User")
-    data class User(@JsonValue(true) val data: OwnerData) : Owner(), java.io.Serializable {val type = "User"}
+    data class User(@JsonValue(true) val data: OwnerData) : Owner(), java.io.Serializable {
+        val type = "User"
+    }
 
     @Serializable
     @JsonTypeName("Organization")
-    data class Organization(@JsonValue(true) val data: OrganizationData) : Owner(), java.io.Serializable {val type = "Organization"}
+    data class Organization(@JsonValue(true) val data: OrganizationData) : Owner(), java.io.Serializable {
+        val type = "Organization"
+    }
 }
 
 @Serializable
@@ -268,7 +272,9 @@ data class PushData(
 sealed class WebhookEvent : java.io.Serializable {
     @Serializable
     @JsonTypeName("push")
-    data class Push(val data: PushData) : WebhookEvent(), java.io.Serializable {val type = "push"}
+    data class Push(val data: PushData) : WebhookEvent(), java.io.Serializable {
+        val type = "push"
+    }
 }
 
 @Serializable

--- a/test/reference-output/hasGeneric.kt
+++ b/test/reference-output/hasGeneric.kt
@@ -22,11 +22,15 @@ class HasGeneric {
 sealed class Result<T, E> : java.io.Serializable {
     @Serializable
     @JsonTypeName("Success")
-    data class Success<T, E>(val data: T) : Result<T, E>(), java.io.Serializable {val type = "Success"}
+    data class Success<T, E>(val data: T) : Result<T, E>(), java.io.Serializable {
+        val type = "Success"
+    }
 
     @Serializable
     @JsonTypeName("Failure")
-    data class Failure<T, E>(val data: E) : Result<T, E>(), java.io.Serializable {val type = "Failure"}
+    data class Failure<T, E>(val data: E) : Result<T, E>(), java.io.Serializable {
+        val type = "Failure"
+    }
 }
 
 @Serializable
@@ -52,10 +56,14 @@ data class MaybeHolder<T>(
 sealed class HasGenericEvent<T> : java.io.Serializable {
     @Serializable
     @JsonTypeName("PlainEvent")
-    data class PlainEvent<T>(val data: Other_Plain) : HasGenericEvent<T>(), java.io.Serializable {val type = "PlainEvent"}
+    data class PlainEvent<T>(val data: Other_Plain) : HasGenericEvent<T>(), java.io.Serializable {
+        val type = "PlainEvent"
+    }
 
     @Serializable
     @JsonTypeName("GenericEvent")
-    data class GenericEvent<T>(val data: External_Option<T>) : HasGenericEvent<T>(), java.io.Serializable {val type = "GenericEvent"}
+    data class GenericEvent<T>(val data: External_Option<T>) : HasGenericEvent<T>(), java.io.Serializable {
+        val type = "GenericEvent"
+    }
 }
 }

--- a/test/reference-output/importExample.kt
+++ b/test/reference-output/importExample.kt
@@ -42,11 +42,15 @@ data class StructureUsingImport(
 sealed class UnionUsingImport : java.io.Serializable {
     @Serializable
     @JsonTypeName("CoolEvent")
-    data class CoolEvent(val data: Basic.Event) : UnionUsingImport(), java.io.Serializable {val type = "CoolEvent"}
+    data class CoolEvent(val data: Basic.Event) : UnionUsingImport(), java.io.Serializable {
+        val type = "CoolEvent"
+    }
 
     @Serializable
     @JsonTypeName("Other")
-    data class Other(val data: Basic.Person) : UnionUsingImport(), java.io.Serializable {val type = "Other"}
+    data class Other(val data: Basic.Person) : UnionUsingImport(), java.io.Serializable {
+        val type = "Other"
+    }
 }
 
 @Serializable


### PR DESCRIPTION
Since we are using `class` for them we have to provide a check so that we don't end up defaulting to reference equality.