### PR TITLE
fix: fix type parameter having higher priority than definition references

### DIFF
--- a/gotyno-hs.cabal
+++ b/gotyno-hs.cabal
@@ -78,6 +78,7 @@ extra-source-files:
     test/examples/relaxedWhiteSpace.gotyno
     test/examples/result.gotyno
     test/examples/tooManyAppliedImportedTypeParameters.gotyno
+    test/examples/typeVariableParsingAfterDefinitionReference.gotyno
     test/examples/untaggedUnionValidator.gotyno
     test/examples/untaggedUnionWithDeclaration.gotyno
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:    gotyno-hs
-version: 1.2.16
+version: 1.2.17
 synopsis: A type definition compiler supporting multiple output languages.
 description: Compiles type definitions into F#, TypeScript and Python, with validators, decoders and encoders.
 license: BSD2

--- a/src/Parsing.hs
+++ b/src/Parsing.hs
@@ -367,8 +367,8 @@ fieldTypeP imports typeVariables =
   choice
     [ LiteralType <$> literalP,
       ComplexType <$> complexTypeP imports typeVariables,
-      TypeVariableReferenceType <$> typeVariableReferenceP typeVariables,
       DefinitionReferenceType <$> definitionReferenceP imports typeVariables,
+      TypeVariableReferenceType <$> typeVariableReferenceP typeVariables,
       BasicType <$> basicTypeValueP,
       DefinitionReferenceType <$> importedReferenceP imports typeVariables,
       RecursiveReferenceType <$> recursiveReferenceP

--- a/test/ParsingSpec.hs
+++ b/test/ParsingSpec.hs
@@ -410,6 +410,11 @@ spec
             ]
         isLeft result `shouldBe` True
 
+    describe "Type parameter regression tests" $ do
+      it "Should be able to parse definition name when it starts with a type parameter char" $ do
+        result <- parseModules ["test/examples/typeVariableParsingAfterDefinitionReference.gotyno"]
+        shouldBeRight result
+
     describe "Reference output" $ do
       it "Gives the correct parsed output for `basic.gotyno`" $ do
         Module {_moduleName = name, _moduleImports = imports, _moduleDefinitions = definitions} <-

--- a/test/examples/typeVariableParsingAfterDefinitionReference.gotyno
+++ b/test/examples/typeVariableParsingAfterDefinitionReference.gotyno
@@ -1,0 +1,7 @@
+struct TStruct {
+  field: U32
+}
+
+struct GenericStruct <T>{
+  field: TStruct
+}


### PR DESCRIPTION
This was causing definitions to not be parsed when their names started with the same character as a type parameter.