### PR TITLE
fix: output correct type for optional constructor arguments in TypeScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2.2.0
+
+### Added
+
+- More tests for TypeScript output; the "basic" suite
+
+### Fixes
+- Fixed bug where TypeScript's optional parameters to constructors would not
+  use `?`, i.e. `function Constructor(data?: string)`.
+
+## 2.1.0
+
+### Fixes
+
+- Made it so Kotlin started using types from enum definitions instead of `Any`.
+
 ## 2.0.0
 
 ### Breaking changes

--- a/gotyno-hs.cabal
+++ b/gotyno-hs.cabal
@@ -35,6 +35,7 @@ extra-source-files:
     test/reference-output/basicUnion.ts
     test/reference-output/external.ts
     test/reference-output/generics.ts
+    test/reference-output/genericStruct.ts
     test/reference-output/github.ts
     test/reference-output/hasGeneric.ts
     test/reference-output/importExample.ts

--- a/gotyno-hs.cabal
+++ b/gotyno-hs.cabal
@@ -36,6 +36,7 @@ extra-source-files:
     test/reference-output/external.ts
     test/reference-output/generics.ts
     test/reference-output/genericStruct.ts
+    test/reference-output/genericUnion.ts
     test/reference-output/github.ts
     test/reference-output/hasGeneric.ts
     test/reference-output/importExample.ts

--- a/gotyno-hs.cabal
+++ b/gotyno-hs.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           gotyno-hs
-version:        2.1.0
+version:        2.2.0
 synopsis:       A type definition compiler supporting multiple output languages.
 description:    Compiles type definitions into F#, TypeScript and Python, with validators, decoders and encoders.
 category:       Compiler

--- a/gotyno-hs.cabal
+++ b/gotyno-hs.cabal
@@ -32,6 +32,7 @@ extra-source-files:
     test/reference-output/arrayOfArraysOfNullableStrings.ts
     test/reference-output/basic.ts
     test/reference-output/basicEnumeration.ts
+    test/reference-output/basicImport.ts
     test/reference-output/basicStruct.ts
     test/reference-output/basicUnion.ts
     test/reference-output/external.ts

--- a/gotyno-hs.cabal
+++ b/gotyno-hs.cabal
@@ -33,6 +33,7 @@ extra-source-files:
     test/reference-output/basic.ts
     test/reference-output/basicEnumeration.ts
     test/reference-output/basicImport.ts
+    test/reference-output/basicOptional.ts
     test/reference-output/basicStruct.ts
     test/reference-output/basicUnion.ts
     test/reference-output/external.ts

--- a/gotyno-hs.cabal
+++ b/gotyno-hs.cabal
@@ -31,6 +31,7 @@ extra-source-files:
     examples/python.gotyno
     test/reference-output/arrayOfArraysOfNullableStrings.ts
     test/reference-output/basic.ts
+    test/reference-output/basicEnumeration.ts
     test/reference-output/basicStruct.ts
     test/reference-output/basicUnion.ts
     test/reference-output/external.ts

--- a/gotyno-hs.cabal
+++ b/gotyno-hs.cabal
@@ -31,6 +31,7 @@ extra-source-files:
     examples/python.gotyno
     test/reference-output/arrayOfArraysOfNullableStrings.ts
     test/reference-output/basic.ts
+    test/reference-output/basicStruct.ts
     test/reference-output/external.ts
     test/reference-output/generics.ts
     test/reference-output/github.ts

--- a/gotyno-hs.cabal
+++ b/gotyno-hs.cabal
@@ -32,6 +32,7 @@ extra-source-files:
     test/reference-output/arrayOfArraysOfNullableStrings.ts
     test/reference-output/basic.ts
     test/reference-output/basicStruct.ts
+    test/reference-output/basicUnion.ts
     test/reference-output/external.ts
     test/reference-output/generics.ts
     test/reference-output/github.ts

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:    gotyno-hs
-version: 2.1.0
+version: 2.2.0
 synopsis: A type definition compiler supporting multiple output languages.
 description: Compiles type definitions into F#, TypeScript and Python, with validators, decoders and encoders.
 license: BSD2

--- a/src/CodeGeneration/TypeScript.hs
+++ b/src/CodeGeneration/TypeScript.hs
@@ -1038,7 +1038,10 @@ outputCaseType
   unionName
   (FieldName tag)
   (Constructor (ConstructorName name) maybePayload) =
-    let payloadLine = maybe "" (\p -> "    data: " <> outputFieldType p <> ";\n") maybePayload
+    let payloadLine = maybe "" outputDataField maybePayload
+        outputDataField (ComplexType (OptionalType t)) =
+          mconcat ["    data?: ", outputFieldType t, ";\n"]
+        outputDataField t = mconcat ["    data: ", outputFieldType t, ";\n"]
         maybeTypeVariables = maybe "" (typeVariablesFrom >>> maybeJoinTypeVariables) maybePayload
      in mconcat
           [ mconcat ["export type ", upperCaseFirst name, maybeTypeVariables, " = {\n"],
@@ -1058,7 +1061,9 @@ outputCaseConstructor
   unionName
   (FieldName tag)
   (Constructor (ConstructorName name) maybePayload) =
-    let argumentFieldAndType = maybe "" (\p -> "data: " <> outputFieldType p) maybePayload
+    let argumentFieldAndType = maybe "" outputDataParameter maybePayload
+        outputDataParameter (ComplexType (OptionalType t)) = mconcat ["data?: ", outputFieldType t]
+        outputDataParameter t = mconcat ["data: ", outputFieldType t]
         maybeTypeVariables = maybe "" joinTypeVariables (maybePayload >>= typeVariablesFrom)
      in mconcat
           [ mconcat

--- a/test/ParsingSpec.hs
+++ b/test/ParsingSpec.hs
@@ -24,6 +24,7 @@ data TypeScriptReferenceOutput = TypeScriptReferenceOutput
     basicUnion :: !Text,
     genericStruct :: !Text,
     genericUnion :: !Text,
+    basicEnumeration :: !Text,
     basic :: !Text,
     import' :: !Text,
     hasGeneric :: !Text,
@@ -81,6 +82,7 @@ typeScriptReferenceOutput = do
   basicUnion <- basicUnionReferenceOutput "ts"
   genericStruct <- genericStructReferenceOutput "ts"
   genericUnion <- genericUnionReferenceOutput "ts"
+  basicEnumeration <- basicEnumerationReferenceOutput "ts"
   basic <- basicReferenceOutput "ts"
   import' <- importReferenceOutput "ts"
   hasGeneric <- hasGenericReferenceOutput "ts"
@@ -92,6 +94,7 @@ typeScriptReferenceOutput = do
         basicUnion,
         genericStruct,
         genericUnion,
+        basicEnumeration,
         basic,
         import',
         hasGeneric,
@@ -222,6 +225,7 @@ spec
       tsBasicUnion
       tsGenericStruct
       tsGenericUnion
+      tsBasicEnumeration
       tsBasic
       tsImport
       tsHasGeneric
@@ -573,6 +577,7 @@ spec
       it "Mirrors reference output for `basicEnumeration.gotyno`" $ do
         enumerationModule <-
           (getRight >>> PartialList.head) <$> parseModules ["examples/basicEnumeration.gotyno"]
+        TypeScript.outputModule enumerationModule `shouldBe` tsBasicEnumeration
         DLang.outputModule enumerationModule `shouldBe` dBasicEnumeration
 
       it "Mirrors reference output for `basicImport.gotyno`" $ do

--- a/test/ParsingSpec.hs
+++ b/test/ParsingSpec.hs
@@ -12,8 +12,16 @@ import qualified RIO.List.Partial as PartialList
 import Test.Hspec
 import Types
 
+-- { basicStruct :: !Text,
+--   basicUnion :: !Text,
+--   genericStruct :: !Text,
+--   genericUnion :: !Text,
+--   basicEnumeration :: !Text,
+--   basicImport :: !Text,
+--   basicOptional :: !Text,
 data TypeScriptReferenceOutput = TypeScriptReferenceOutput
-  { basic :: !Text,
+  { basicStruct :: !Text,
+    basic :: !Text,
     import' :: !Text,
     hasGeneric :: !Text,
     generics :: !Text,
@@ -66,12 +74,21 @@ data DLangReferenceOutput = DLangReferenceOutput
 
 typeScriptReferenceOutput :: IO TypeScriptReferenceOutput
 typeScriptReferenceOutput = do
+  basicStruct <- basicStructReferenceOutput "ts"
   basic <- basicReferenceOutput "ts"
   import' <- importReferenceOutput "ts"
   hasGeneric <- hasGenericReferenceOutput "ts"
   generics <- genericsReferenceOutput "ts"
   gitHub <- gitHubReferenceOutput "ts"
-  pure TypeScriptReferenceOutput {basic, import', hasGeneric, generics, gitHub}
+  pure
+    TypeScriptReferenceOutput
+      { basicStruct,
+        basic,
+        import',
+        hasGeneric,
+        generics,
+        gitHub
+      }
 
 haskellReferenceOutput :: IO HaskellReferenceOutput
 haskellReferenceOutput = do
@@ -191,7 +208,7 @@ spec ::
   DLangReferenceOutput ->
   Spec
 spec
-  (TypeScriptReferenceOutput tsBasic tsImport tsHasGeneric tsGenerics tsGitHub)
+  (TypeScriptReferenceOutput tsBasicStruct tsBasic tsImport tsHasGeneric tsGenerics tsGitHub)
   (HaskellReferenceOutput hsBasic hsImport hsHasGeneric hsGenerics hsGitHub)
   (FSharpReferenceOutput fsBasic fsImport fsHasGeneric fsGenerics fsGitHub)
   (PythonReferenceOutput pyPython pyBasic pyGenerics)
@@ -513,6 +530,7 @@ spec
       it "Mirrors reference output for `basicStruct.gotyno`" $ do
         basicStructModule <-
           (getRight >>> PartialList.head) <$> parseModules ["examples/basicStruct.gotyno"]
+        TypeScript.outputModule basicStructModule `shouldBe` tsBasicStruct
         DLang.outputModule basicStructModule `shouldBe` dBasicStruct
 
       it "Mirrors reference output for `basicUnion.gotyno`" $ do

--- a/test/ParsingSpec.hs
+++ b/test/ParsingSpec.hs
@@ -22,6 +22,7 @@ import Types
 data TypeScriptReferenceOutput = TypeScriptReferenceOutput
   { basicStruct :: !Text,
     basicUnion :: !Text,
+    genericStruct :: !Text,
     basic :: !Text,
     import' :: !Text,
     hasGeneric :: !Text,
@@ -77,6 +78,7 @@ typeScriptReferenceOutput :: IO TypeScriptReferenceOutput
 typeScriptReferenceOutput = do
   basicStruct <- basicStructReferenceOutput "ts"
   basicUnion <- basicUnionReferenceOutput "ts"
+  genericStruct <- genericStructReferenceOutput "ts"
   basic <- basicReferenceOutput "ts"
   import' <- importReferenceOutput "ts"
   hasGeneric <- hasGenericReferenceOutput "ts"
@@ -86,6 +88,7 @@ typeScriptReferenceOutput = do
     TypeScriptReferenceOutput
       { basicStruct,
         basicUnion,
+        genericStruct,
         basic,
         import',
         hasGeneric,
@@ -214,6 +217,7 @@ spec
   ( TypeScriptReferenceOutput
       tsBasicStruct
       tsBasicUnion
+      tsGenericStruct
       tsBasic
       tsImport
       tsHasGeneric
@@ -553,6 +557,7 @@ spec
       it "Mirrors reference output for `genericStruct.gotyno`" $ do
         genericStructModule <-
           (getRight >>> PartialList.head) <$> parseModules ["examples/genericStruct.gotyno"]
+        TypeScript.outputModule genericStructModule `shouldBe` tsGenericStruct
         DLang.outputModule genericStructModule `shouldBe` dGenericStruct
 
       it "Mirrors reference output for `genericUnion.gotyno`" $ do

--- a/test/ParsingSpec.hs
+++ b/test/ParsingSpec.hs
@@ -23,6 +23,7 @@ data TypeScriptReferenceOutput = TypeScriptReferenceOutput
   { basicStruct :: !Text,
     basicUnion :: !Text,
     genericStruct :: !Text,
+    genericUnion :: !Text,
     basic :: !Text,
     import' :: !Text,
     hasGeneric :: !Text,
@@ -79,6 +80,7 @@ typeScriptReferenceOutput = do
   basicStruct <- basicStructReferenceOutput "ts"
   basicUnion <- basicUnionReferenceOutput "ts"
   genericStruct <- genericStructReferenceOutput "ts"
+  genericUnion <- genericUnionReferenceOutput "ts"
   basic <- basicReferenceOutput "ts"
   import' <- importReferenceOutput "ts"
   hasGeneric <- hasGenericReferenceOutput "ts"
@@ -89,6 +91,7 @@ typeScriptReferenceOutput = do
       { basicStruct,
         basicUnion,
         genericStruct,
+        genericUnion,
         basic,
         import',
         hasGeneric,
@@ -218,6 +221,7 @@ spec
       tsBasicStruct
       tsBasicUnion
       tsGenericStruct
+      tsGenericUnion
       tsBasic
       tsImport
       tsHasGeneric
@@ -563,6 +567,7 @@ spec
       it "Mirrors reference output for `genericUnion.gotyno`" $ do
         genericUnionModule <-
           (getRight >>> PartialList.head) <$> parseModules ["examples/genericUnion.gotyno"]
+        TypeScript.outputModule genericUnionModule `shouldBe` tsGenericUnion
         DLang.outputModule genericUnionModule `shouldBe` dGenericUnion
 
       it "Mirrors reference output for `basicEnumeration.gotyno`" $ do

--- a/test/ParsingSpec.hs
+++ b/test/ParsingSpec.hs
@@ -21,6 +21,7 @@ import Types
 --   basicOptional :: !Text,
 data TypeScriptReferenceOutput = TypeScriptReferenceOutput
   { basicStruct :: !Text,
+    basicUnion :: !Text,
     basic :: !Text,
     import' :: !Text,
     hasGeneric :: !Text,
@@ -75,6 +76,7 @@ data DLangReferenceOutput = DLangReferenceOutput
 typeScriptReferenceOutput :: IO TypeScriptReferenceOutput
 typeScriptReferenceOutput = do
   basicStruct <- basicStructReferenceOutput "ts"
+  basicUnion <- basicUnionReferenceOutput "ts"
   basic <- basicReferenceOutput "ts"
   import' <- importReferenceOutput "ts"
   hasGeneric <- hasGenericReferenceOutput "ts"
@@ -83,6 +85,7 @@ typeScriptReferenceOutput = do
   pure
     TypeScriptReferenceOutput
       { basicStruct,
+        basicUnion,
         basic,
         import',
         hasGeneric,
@@ -208,7 +211,15 @@ spec ::
   DLangReferenceOutput ->
   Spec
 spec
-  (TypeScriptReferenceOutput tsBasicStruct tsBasic tsImport tsHasGeneric tsGenerics tsGitHub)
+  ( TypeScriptReferenceOutput
+      tsBasicStruct
+      tsBasicUnion
+      tsBasic
+      tsImport
+      tsHasGeneric
+      tsGenerics
+      tsGitHub
+    )
   (HaskellReferenceOutput hsBasic hsImport hsHasGeneric hsGenerics hsGitHub)
   (FSharpReferenceOutput fsBasic fsImport fsHasGeneric fsGenerics fsGitHub)
   (PythonReferenceOutput pyPython pyBasic pyGenerics)
@@ -536,6 +547,7 @@ spec
       it "Mirrors reference output for `basicUnion.gotyno`" $ do
         basicUnionModule <-
           (getRight >>> PartialList.head) <$> parseModules ["examples/basicUnion.gotyno"]
+        TypeScript.outputModule basicUnionModule `shouldBe` tsBasicUnion
         DLang.outputModule basicUnionModule `shouldBe` dBasicUnion
 
       it "Mirrors reference output for `genericStruct.gotyno`" $ do

--- a/test/ParsingSpec.hs
+++ b/test/ParsingSpec.hs
@@ -12,13 +12,6 @@ import qualified RIO.List.Partial as PartialList
 import Test.Hspec
 import Types
 
--- { basicStruct :: !Text,
---   basicUnion :: !Text,
---   genericStruct :: !Text,
---   genericUnion :: !Text,
---   basicEnumeration :: !Text,
---   basicImport :: !Text,
---   basicOptional :: !Text,
 data TypeScriptReferenceOutput = TypeScriptReferenceOutput
   { basicStruct :: !Text,
     basicUnion :: !Text,
@@ -26,6 +19,7 @@ data TypeScriptReferenceOutput = TypeScriptReferenceOutput
     genericUnion :: !Text,
     basicEnumeration :: !Text,
     basicImport :: !Text,
+    basicOptional :: !Text,
     basic :: !Text,
     import' :: !Text,
     hasGeneric :: !Text,
@@ -85,6 +79,7 @@ typeScriptReferenceOutput = do
   genericUnion <- genericUnionReferenceOutput "ts"
   basicEnumeration <- basicEnumerationReferenceOutput "ts"
   basicImport <- basicImportReferenceOutput "ts"
+  basicOptional <- basicOptionalReferenceOutput "ts"
   basic <- basicReferenceOutput "ts"
   import' <- importReferenceOutput "ts"
   hasGeneric <- hasGenericReferenceOutput "ts"
@@ -98,6 +93,7 @@ typeScriptReferenceOutput = do
         genericUnion,
         basicEnumeration,
         basicImport,
+        basicOptional,
         basic,
         import',
         hasGeneric,
@@ -230,6 +226,7 @@ spec
       tsGenericUnion
       tsBasicEnumeration
       tsBasicImport
+      tsBasicOptional
       tsBasic
       tsImport
       tsHasGeneric
@@ -594,6 +591,7 @@ spec
       it "Mirrors reference output for `basicOptional.gotyno`" $ do
         basicOptionalModule <-
           (getRight >>> PartialList.head) <$> parseModules ["examples/basicOptional.gotyno"]
+        TypeScript.outputModule basicOptionalModule `shouldBe` tsBasicOptional
         DLang.outputModule basicOptionalModule `shouldBe` dBasicOptional
 
       it "Mirrors reference output for `basic.gotyno`" $ do

--- a/test/ParsingSpec.hs
+++ b/test/ParsingSpec.hs
@@ -25,6 +25,7 @@ data TypeScriptReferenceOutput = TypeScriptReferenceOutput
     genericStruct :: !Text,
     genericUnion :: !Text,
     basicEnumeration :: !Text,
+    basicImport :: !Text,
     basic :: !Text,
     import' :: !Text,
     hasGeneric :: !Text,
@@ -83,6 +84,7 @@ typeScriptReferenceOutput = do
   genericStruct <- genericStructReferenceOutput "ts"
   genericUnion <- genericUnionReferenceOutput "ts"
   basicEnumeration <- basicEnumerationReferenceOutput "ts"
+  basicImport <- basicImportReferenceOutput "ts"
   basic <- basicReferenceOutput "ts"
   import' <- importReferenceOutput "ts"
   hasGeneric <- hasGenericReferenceOutput "ts"
@@ -95,6 +97,7 @@ typeScriptReferenceOutput = do
         genericStruct,
         genericUnion,
         basicEnumeration,
+        basicImport,
         basic,
         import',
         hasGeneric,
@@ -226,6 +229,7 @@ spec
       tsGenericStruct
       tsGenericUnion
       tsBasicEnumeration
+      tsBasicImport
       tsBasic
       tsImport
       tsHasGeneric
@@ -584,6 +588,7 @@ spec
         basicImportModule <-
           (getRight >>> PartialList.last)
             <$> parseModules ["examples/basicStruct.gotyno", "examples/basicImport.gotyno"]
+        TypeScript.outputModule basicImportModule `shouldBe` tsBasicImport
         DLang.outputModule basicImportModule `shouldBe` dBasicImport
 
       it "Mirrors reference output for `basicOptional.gotyno`" $ do

--- a/test/reference-output/basicEnumeration.ts
+++ b/test/reference-output/basicEnumeration.ts
@@ -1,0 +1,31 @@
+import * as svt from "simple-validation-tools";
+
+export enum StringValues {
+    first = "first",
+    second = "second",
+    third = "Third",
+    fourth = "Fourth",
+}
+
+export function isStringValues(value: unknown): value is StringValues {
+    return [StringValues.first, StringValues.second, StringValues.third, StringValues.fourth].some((v) => v === value);
+}
+
+export function validateStringValues(value: unknown): svt.ValidationResult<StringValues> {
+    return svt.validateOneOfLiterals<StringValues>(value, [StringValues.first, StringValues.second, StringValues.third, StringValues.fourth]);
+}
+
+export enum IntValues {
+    first = 1,
+    second = 2,
+    third = 3,
+    fourth = 4,
+}
+
+export function isIntValues(value: unknown): value is IntValues {
+    return [IntValues.first, IntValues.second, IntValues.third, IntValues.fourth].some((v) => v === value);
+}
+
+export function validateIntValues(value: unknown): svt.ValidationResult<IntValues> {
+    return svt.validateOneOfLiterals<IntValues>(value, [IntValues.first, IntValues.second, IntValues.third, IntValues.fourth]);
+}

--- a/test/reference-output/basicImport.ts
+++ b/test/reference-output/basicImport.ts
@@ -1,0 +1,46 @@
+import * as svt from "simple-validation-tools";
+
+import * as basicStruct from "./basicStruct";
+
+export type StructUsingImport = {
+    field: basicStruct.BasicStruct;
+};
+
+export function isStructUsingImport(value: unknown): value is StructUsingImport {
+    return svt.isInterface<StructUsingImport>(value, {field: basicStruct.isBasicStruct});
+}
+
+export function validateStructUsingImport(value: unknown): svt.ValidationResult<StructUsingImport> {
+    return svt.validate<StructUsingImport>(value, {field: basicStruct.validateBasicStruct});
+}
+
+export type UnionUsingImport = ConstructorWithPayload;
+
+export enum UnionUsingImportTag {
+    ConstructorWithPayload = "ConstructorWithPayload",
+}
+
+export type ConstructorWithPayload = {
+    type: UnionUsingImportTag.ConstructorWithPayload;
+    data: basicStruct.BasicStruct;
+};
+
+export function ConstructorWithPayload(data: basicStruct.BasicStruct): ConstructorWithPayload {
+    return {type: UnionUsingImportTag.ConstructorWithPayload, data};
+}
+
+export function isUnionUsingImport(value: unknown): value is UnionUsingImport {
+    return [isConstructorWithPayload].some((typePredicate) => typePredicate(value));
+}
+
+export function isConstructorWithPayload(value: unknown): value is ConstructorWithPayload {
+    return svt.isInterface<ConstructorWithPayload>(value, {type: UnionUsingImportTag.ConstructorWithPayload, data: basicStruct.isBasicStruct});
+}
+
+export function validateUnionUsingImport(value: unknown): svt.ValidationResult<UnionUsingImport> {
+    return svt.validateWithTypeTag<UnionUsingImport>(value, {[UnionUsingImportTag.ConstructorWithPayload]: validateConstructorWithPayload}, "type");
+}
+
+export function validateConstructorWithPayload(value: unknown): svt.ValidationResult<ConstructorWithPayload> {
+    return svt.validate<ConstructorWithPayload>(value, {type: UnionUsingImportTag.ConstructorWithPayload, data: basicStruct.validateBasicStruct});
+}

--- a/test/reference-output/basicOptional.ts
+++ b/test/reference-output/basicOptional.ts
@@ -1,0 +1,82 @@
+import * as svt from "simple-validation-tools";
+
+export type HasOptionalString = {
+    stringField?: string;
+    optionalArrayField?: number[];
+    arrayOfOptionalField: (number | null | undefined)[];
+};
+
+export function isHasOptionalString(value: unknown): value is HasOptionalString {
+    return svt.isInterface<HasOptionalString>(value, {stringField: svt.optional(svt.isString), optionalArrayField: svt.optional(svt.arrayOf(svt.isNumber)), arrayOfOptionalField: svt.arrayOf(svt.optional(svt.isNumber))});
+}
+
+export function validateHasOptionalString(value: unknown): svt.ValidationResult<HasOptionalString> {
+    return svt.validate<HasOptionalString>(value, {stringField: svt.validateOptional(svt.validateString), optionalArrayField: svt.validateOptional(svt.validateArray(svt.validateNumber)), arrayOfOptionalField: svt.validateArray(svt.validateOptional(svt.validateNumber))});
+}
+
+export type HasOptionalConstructor = DoesNot | Does | HasOptionalStruct;
+
+export enum HasOptionalConstructorTag {
+    DoesNot = "DoesNot",
+    Does = "Does",
+    HasOptionalStruct = "HasOptionalStruct",
+}
+
+export type DoesNot = {
+    type: HasOptionalConstructorTag.DoesNot;
+    data: number;
+};
+
+export type Does = {
+    type: HasOptionalConstructorTag.Does;
+    data?: number;
+};
+
+export type HasOptionalStruct = {
+    type: HasOptionalConstructorTag.HasOptionalStruct;
+    data?: HasOptionalString;
+};
+
+export function DoesNot(data: number): DoesNot {
+    return {type: HasOptionalConstructorTag.DoesNot, data};
+}
+
+export function Does(data?: number): Does {
+    return {type: HasOptionalConstructorTag.Does, data};
+}
+
+export function HasOptionalStruct(data?: HasOptionalString): HasOptionalStruct {
+    return {type: HasOptionalConstructorTag.HasOptionalStruct, data};
+}
+
+export function isHasOptionalConstructor(value: unknown): value is HasOptionalConstructor {
+    return [isDoesNot, isDoes, isHasOptionalStruct].some((typePredicate) => typePredicate(value));
+}
+
+export function isDoesNot(value: unknown): value is DoesNot {
+    return svt.isInterface<DoesNot>(value, {type: HasOptionalConstructorTag.DoesNot, data: svt.isNumber});
+}
+
+export function isDoes(value: unknown): value is Does {
+    return svt.isInterface<Does>(value, {type: HasOptionalConstructorTag.Does, data: svt.optional(svt.isNumber)});
+}
+
+export function isHasOptionalStruct(value: unknown): value is HasOptionalStruct {
+    return svt.isInterface<HasOptionalStruct>(value, {type: HasOptionalConstructorTag.HasOptionalStruct, data: svt.optional(isHasOptionalString)});
+}
+
+export function validateHasOptionalConstructor(value: unknown): svt.ValidationResult<HasOptionalConstructor> {
+    return svt.validateWithTypeTag<HasOptionalConstructor>(value, {[HasOptionalConstructorTag.DoesNot]: validateDoesNot, [HasOptionalConstructorTag.Does]: validateDoes, [HasOptionalConstructorTag.HasOptionalStruct]: validateHasOptionalStruct}, "type");
+}
+
+export function validateDoesNot(value: unknown): svt.ValidationResult<DoesNot> {
+    return svt.validate<DoesNot>(value, {type: HasOptionalConstructorTag.DoesNot, data: svt.validateNumber});
+}
+
+export function validateDoes(value: unknown): svt.ValidationResult<Does> {
+    return svt.validate<Does>(value, {type: HasOptionalConstructorTag.Does, data: svt.validateOptional(svt.validateNumber)});
+}
+
+export function validateHasOptionalStruct(value: unknown): svt.ValidationResult<HasOptionalStruct> {
+    return svt.validate<HasOptionalStruct>(value, {type: HasOptionalConstructorTag.HasOptionalStruct, data: svt.validateOptional(validateHasOptionalString)});
+}

--- a/test/reference-output/basicStruct.ts
+++ b/test/reference-output/basicStruct.ts
@@ -1,0 +1,14 @@
+import * as svt from "simple-validation-tools";
+
+export type BasicStruct = {
+    field1: number;
+    field2: string;
+};
+
+export function isBasicStruct(value: unknown): value is BasicStruct {
+    return svt.isInterface<BasicStruct>(value, {field1: svt.isNumber, field2: svt.isString});
+}
+
+export function validateBasicStruct(value: unknown): svt.ValidationResult<BasicStruct> {
+    return svt.validate<BasicStruct>(value, {field1: svt.validateNumber, field2: svt.validateString});
+}

--- a/test/reference-output/basicUnion.ts
+++ b/test/reference-output/basicUnion.ts
@@ -1,0 +1,79 @@
+import * as svt from "simple-validation-tools";
+
+export type PayloadStruct = {
+    field1: number;
+};
+
+export function isPayloadStruct(value: unknown): value is PayloadStruct {
+    return svt.isInterface<PayloadStruct>(value, {field1: svt.isNumber});
+}
+
+export function validatePayloadStruct(value: unknown): svt.ValidationResult<PayloadStruct> {
+    return svt.validate<PayloadStruct>(value, {field1: svt.validateNumber});
+}
+
+export type BasicUnion = HasStringPayload | HasPayload | HasNoPayload;
+
+export enum BasicUnionTag {
+    HasStringPayload = "HasStringPayload",
+    HasPayload = "HasPayload",
+    HasNoPayload = "HasNoPayload",
+}
+
+export type HasStringPayload = {
+    type: BasicUnionTag.HasStringPayload;
+    data: string;
+};
+
+export type HasPayload = {
+    type: BasicUnionTag.HasPayload;
+    data: PayloadStruct;
+};
+
+export type HasNoPayload = {
+    type: BasicUnionTag.HasNoPayload;
+};
+
+export function HasStringPayload(data: string): HasStringPayload {
+    return {type: BasicUnionTag.HasStringPayload, data};
+}
+
+export function HasPayload(data: PayloadStruct): HasPayload {
+    return {type: BasicUnionTag.HasPayload, data};
+}
+
+export function HasNoPayload(): HasNoPayload {
+    return {type: BasicUnionTag.HasNoPayload};
+}
+
+export function isBasicUnion(value: unknown): value is BasicUnion {
+    return [isHasStringPayload, isHasPayload, isHasNoPayload].some((typePredicate) => typePredicate(value));
+}
+
+export function isHasStringPayload(value: unknown): value is HasStringPayload {
+    return svt.isInterface<HasStringPayload>(value, {type: BasicUnionTag.HasStringPayload, data: svt.isString});
+}
+
+export function isHasPayload(value: unknown): value is HasPayload {
+    return svt.isInterface<HasPayload>(value, {type: BasicUnionTag.HasPayload, data: isPayloadStruct});
+}
+
+export function isHasNoPayload(value: unknown): value is HasNoPayload {
+    return svt.isInterface<HasNoPayload>(value, {type: BasicUnionTag.HasNoPayload});
+}
+
+export function validateBasicUnion(value: unknown): svt.ValidationResult<BasicUnion> {
+    return svt.validateWithTypeTag<BasicUnion>(value, {[BasicUnionTag.HasStringPayload]: validateHasStringPayload, [BasicUnionTag.HasPayload]: validateHasPayload, [BasicUnionTag.HasNoPayload]: validateHasNoPayload}, "type");
+}
+
+export function validateHasStringPayload(value: unknown): svt.ValidationResult<HasStringPayload> {
+    return svt.validate<HasStringPayload>(value, {type: BasicUnionTag.HasStringPayload, data: svt.validateString});
+}
+
+export function validateHasPayload(value: unknown): svt.ValidationResult<HasPayload> {
+    return svt.validate<HasPayload>(value, {type: BasicUnionTag.HasPayload, data: validatePayloadStruct});
+}
+
+export function validateHasNoPayload(value: unknown): svt.ValidationResult<HasNoPayload> {
+    return svt.validate<HasNoPayload>(value, {type: BasicUnionTag.HasNoPayload});
+}

--- a/test/reference-output/genericStruct.ts
+++ b/test/reference-output/genericStruct.ts
@@ -1,0 +1,17 @@
+import * as svt from "simple-validation-tools";
+
+export type GenericStruct<T> = {
+    field: T;
+};
+
+export function isGenericStruct<T>(isT: svt.TypePredicate<T>): svt.TypePredicate<GenericStruct<T>> {
+    return function isGenericStructT(value: unknown): value is GenericStruct<T> {
+        return svt.isInterface<GenericStruct<T>>(value, {field: isT});
+    };
+}
+
+export function validateGenericStruct<T>(validateT: svt.Validator<T>): svt.Validator<GenericStruct<T>> {
+    return function validateGenericStructT(value: unknown): svt.ValidationResult<GenericStruct<T>> {
+        return svt.validate<GenericStruct<T>>(value, {field: validateT});
+    };
+}

--- a/test/reference-output/genericUnion.ts
+++ b/test/reference-output/genericUnion.ts
@@ -1,0 +1,57 @@
+import * as svt from "simple-validation-tools";
+
+export type GenericUnion<T> = HasTPayload<T> | HasNoPayload;
+
+export enum GenericUnionTag {
+    HasTPayload = "HasTPayload",
+    HasNoPayload = "HasNoPayload",
+}
+
+export type HasTPayload<T> = {
+    type: GenericUnionTag.HasTPayload;
+    data: T;
+};
+
+export type HasNoPayload = {
+    type: GenericUnionTag.HasNoPayload;
+};
+
+export function HasTPayload<T>(data: T): HasTPayload<T> {
+    return {type: GenericUnionTag.HasTPayload, data};
+}
+
+export function HasNoPayload(): HasNoPayload {
+    return {type: GenericUnionTag.HasNoPayload};
+}
+
+export function isGenericUnion<T>(isT: svt.TypePredicate<T>): svt.TypePredicate<GenericUnion<T>> {
+    return function isGenericUnionT(value: unknown): value is GenericUnion<T> {
+        return [isHasTPayload(isT), isHasNoPayload].some((typePredicate) => typePredicate(value));
+    };
+}
+
+export function isHasTPayload<T>(isT: svt.TypePredicate<T>): svt.TypePredicate<HasTPayload<T>> {
+    return function isHasTPayloadT(value: unknown): value is HasTPayload<T> {
+        return svt.isInterface<HasTPayload<T>>(value, {type: GenericUnionTag.HasTPayload, data: isT});
+    };
+}
+
+export function isHasNoPayload(value: unknown): value is HasNoPayload {
+    return svt.isInterface<HasNoPayload>(value, {type: GenericUnionTag.HasNoPayload});
+}
+
+export function validateGenericUnion<T>(validateT: svt.Validator<T>): svt.Validator<GenericUnion<T>> {
+    return function validateGenericUnionT(value: unknown): svt.ValidationResult<GenericUnion<T>> {
+        return svt.validateWithTypeTag<GenericUnion<T>>(value, {[GenericUnionTag.HasTPayload]: validateHasTPayload(validateT), [GenericUnionTag.HasNoPayload]: validateHasNoPayload}, "type");
+    };
+}
+
+export function validateHasTPayload<T>(validateT: svt.Validator<T>): svt.Validator<HasTPayload<T>> {
+    return function validateHasTPayloadT(value: unknown): svt.ValidationResult<HasTPayload<T>> {
+        return svt.validate<HasTPayload<T>>(value, {type: GenericUnionTag.HasTPayload, data: validateT});
+    };
+}
+
+export function validateHasNoPayload(value: unknown): svt.ValidationResult<HasNoPayload> {
+    return svt.validate<HasNoPayload>(value, {type: GenericUnionTag.HasNoPayload});
+}


### PR DESCRIPTION
This adds implementations of the "basic" suite of tests for TypeScript as well as fixes the output for optional constructor arguments in TypeScript output.