### PR TITLE
feat(kt): add companion `create` function for structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.3.0
+
+### Features
+
+- `Struct.create` function in companion object for all generated structs in
+  Kotlin output, which set optional fields to `null` by default.
+
 ## 2.2.3
 
 ### Fixes

--- a/gotyno-hs.cabal
+++ b/gotyno-hs.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           gotyno-hs
-version:        2.2.3
+version:        2.3.0
 synopsis:       A type definition compiler supporting multiple output languages.
 description:    Compiles type definitions into F#, TypeScript and Python, with validators, decoders and encoders.
 category:       Compiler

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:    gotyno-hs
-version: 2.2.3
+version: 2.3.0
 synopsis: A type definition compiler supporting multiple output languages.
 description: Compiles type definitions into F#, TypeScript and Python, with validators, decoders and encoders.
 license: BSD2

--- a/src/CodeGeneration/Utilities.hs
+++ b/src/CodeGeneration/Utilities.hs
@@ -50,6 +50,10 @@ instance HasName FieldName where
   {-# INLINE nameOf #-}
   nameOf = (^. unwrap)
 
+instance HasName StructField where
+  {-# INLINE nameOf #-}
+  nameOf = (^. structFieldName) >>> nameOf
+
 class HasDefinitionName a where
   definitionNameOf :: a -> DefinitionName
 

--- a/test/reference-output/basic.kt
+++ b/test/reference-output/basic.kt
@@ -25,7 +25,13 @@ data class Recruiter(
     val created: BigInteger,
     @get:JsonProperty("type")
     val type: String = "Recruiter"
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(Name: String, emails: ArrayList<String?>, created: BigInteger, recruiter: Recruiter? = null, type: String = "Recruiter"): Recruiter {
+            return Recruiter(type = type, Name = Name, emails = emails, recruiter = recruiter, created = created)
+        }
+    }
+}
 
 @Serializable
 @JsonTypeInfo(
@@ -65,7 +71,13 @@ sealed class GetSearchesFilter : java.io.Serializable {
 data class SearchesParameters(
     @get:JsonProperty("filters")
     val filters: ArrayList<GetSearchesFilter>
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(filters: ArrayList<GetSearchesFilter>): SearchesParameters {
+            return SearchesParameters(filters = filters)
+        }
+    }
+}
 
 enum class StillSize(val data: String) : java.io.Serializable {
     @JsonProperty("w92") W92("w92"),
@@ -83,13 +95,25 @@ data class LogInData(
     val username: String,
     @get:JsonProperty("password")
     val password: String
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(username: String, password: String): LogInData {
+            return LogInData(username = username, password = password)
+        }
+    }
+}
 
 @Serializable
 data class UserId(
     @get:JsonProperty("value")
     val value: String
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(value: String): UserId {
+            return UserId(value = value)
+        }
+    }
+}
 
 @Serializable
 data class Channel(
@@ -97,7 +121,13 @@ data class Channel(
     val name: String,
     @get:JsonProperty("private")
     val private: Boolean
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(name: String, private: Boolean): Channel {
+            return Channel(name = name, private = private)
+        }
+    }
+}
 
 @Serializable
 data class Email(
@@ -105,7 +135,13 @@ data class Email(
     val value: String,
     @get:JsonProperty("public")
     val public: Boolean
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(value: String, public: Boolean): Email {
+            return Email(value = value, public = public)
+        }
+    }
+}
 
 @Serializable
 @JsonTypeInfo(
@@ -205,7 +241,13 @@ data class Person(
     val recruiter: Recruiter,
     @get:JsonProperty("spouse")
     val spouse: Maybe<Person>
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(name: String, age: Byte, efficiency: Float, on_vacation: Boolean, hobbies: ArrayList<String>, last_fifteen_comments: ArrayList<String>, recruiter: Recruiter, spouse: Maybe<Person>): Person {
+            return Person(name = name, age = age, efficiency = efficiency, on_vacation = on_vacation, hobbies = hobbies, last_fifteen_comments = last_fifteen_comments, recruiter = recruiter, spouse = spouse)
+        }
+    }
+}
 
 @Serializable
 @JsonTypeInfo(

--- a/test/reference-output/basicImport.kt
+++ b/test/reference-output/basicImport.kt
@@ -18,7 +18,13 @@ class BasicImport {
 data class StructUsingImport(
     @get:JsonProperty("field")
     val field: BasicStruct.BasicStruct
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(field: BasicStruct.BasicStruct): StructUsingImport {
+            return StructUsingImport(field = field)
+        }
+    }
+}
 
 @Serializable
 @JsonTypeInfo(

--- a/test/reference-output/basicOptional.kt
+++ b/test/reference-output/basicOptional.kt
@@ -20,7 +20,13 @@ data class HasOptionalString(
     val optionalArrayField: ArrayList<Int>?,
     @get:JsonProperty("arrayOfOptionalField")
     val arrayOfOptionalField: ArrayList<Int?>
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(arrayOfOptionalField: ArrayList<Int?>, stringField: String? = null, optionalArrayField: ArrayList<Int>? = null): HasOptionalString {
+            return HasOptionalString(stringField = stringField, optionalArrayField = optionalArrayField, arrayOfOptionalField = arrayOfOptionalField)
+        }
+    }
+}
 
 @Serializable
 @JsonTypeInfo(

--- a/test/reference-output/basicStruct.kt
+++ b/test/reference-output/basicStruct.kt
@@ -18,5 +18,11 @@ data class BasicStruct(
     val field1: Int,
     @get:JsonProperty("field2")
     val field2: String
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(field1: Int, field2: String): BasicStruct {
+            return BasicStruct(field1 = field1, field2 = field2)
+        }
+    }
+}
 }

--- a/test/reference-output/basicUnion.kt
+++ b/test/reference-output/basicUnion.kt
@@ -16,7 +16,13 @@ class BasicUnion {
 data class PayloadStruct(
     @get:JsonProperty("field1")
     val field1: Int
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(field1: Int): PayloadStruct {
+            return PayloadStruct(field1 = field1)
+        }
+    }
+}
 
 @Serializable
 @JsonTypeInfo(

--- a/test/reference-output/genericStruct.kt
+++ b/test/reference-output/genericStruct.kt
@@ -16,5 +16,11 @@ class GenericStruct {
 data class GenericStruct<T>(
     @get:JsonProperty("field")
     val field: T
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun <T> create(field: T): GenericStruct<T> {
+            return GenericStruct(field = field)
+        }
+    }
+}
 }

--- a/test/reference-output/generics.kt
+++ b/test/reference-output/generics.kt
@@ -21,13 +21,25 @@ data class UsingGenerics(
     val field1: Basic.Maybe<String>,
     @get:JsonProperty("field2")
     val field2: Basic.Either<String, Int>
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(field1: Basic.Maybe<String>, field2: Basic.Either<String, Int>): UsingGenerics {
+            return UsingGenerics(field1 = field1, field2 = field2)
+        }
+    }
+}
 
 @Serializable
 data class UsingOwnGenerics<T>(
     @get:JsonProperty("field1")
     val field1: Basic.Maybe<T>
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun <T> create(field1: Basic.Maybe<T>): UsingOwnGenerics<T> {
+            return UsingOwnGenerics(field1 = field1)
+        }
+    }
+}
 
 @Serializable
 data class KnownForMovie(
@@ -45,7 +57,13 @@ data class KnownForMovie(
     val overview: String,
     @get:JsonProperty("media_type")
     val media_type: String = "movie"
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(id: Int, vote_average: Float, overview: String, poster_path: String? = null, title: String? = null, release_date: String? = null, media_type: String = "movie"): KnownForMovie {
+            return KnownForMovie(media_type = media_type, poster_path = poster_path, id = id, title = title, vote_average = vote_average, release_date = release_date, overview = overview)
+        }
+    }
+}
 
 @Serializable
 data class KnownForShow(
@@ -63,7 +81,13 @@ data class KnownForShow(
     val name: String?,
     @get:JsonProperty("media_type")
     val media_type: String = "tv"
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(id: Int, vote_average: Float, overview: String, poster_path: String? = null, first_air_date: String? = null, name: String? = null, media_type: String = "tv"): KnownForShow {
+            return KnownForShow(media_type = media_type, poster_path = poster_path, id = id, vote_average = vote_average, overview = overview, first_air_date = first_air_date, name = name)
+        }
+    }
+}
 
 @JsonDeserialize(using = KnownFor.Deserializer::class)
 @Serializable
@@ -105,7 +129,13 @@ data class KnownForMovieWithoutTypeTag(
     val release_date: String?,
     @get:JsonProperty("overview")
     val overview: String
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(id: Int, vote_average: Float, overview: String, poster_path: String? = null, title: String? = null, release_date: String? = null): KnownForMovieWithoutTypeTag {
+            return KnownForMovieWithoutTypeTag(poster_path = poster_path, id = id, title = title, vote_average = vote_average, release_date = release_date, overview = overview)
+        }
+    }
+}
 
 @Serializable
 data class KnownForShowWithoutTypeTag(
@@ -121,7 +151,13 @@ data class KnownForShowWithoutTypeTag(
     val first_air_date: String?,
     @get:JsonProperty("name")
     val name: String?
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(id: Int, vote_average: Float, overview: String, poster_path: String? = null, first_air_date: String? = null, name: String? = null): KnownForShowWithoutTypeTag {
+            return KnownForShowWithoutTypeTag(poster_path = poster_path, id = id, vote_average = vote_average, overview = overview, first_air_date = first_air_date, name = name)
+        }
+    }
+}
 
 @Serializable
 @JsonTypeInfo(

--- a/test/reference-output/github.kt
+++ b/test/reference-output/github.kt
@@ -48,7 +48,13 @@ data class UserData(
     val location: String?,
     @get:JsonProperty("blog")
     val blog: String?
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(login: String, id: Int, avatar_url: String, url: String, html_url: String, followers_url: String, gists_url: String, repos_url: String, site_admin: Boolean, bio: String, public_repos: Int, followers: Int, following: Int, created_at: String, updated_at: String, location: String? = null, blog: String? = null): UserData {
+            return UserData(login = login, id = id, avatar_url = avatar_url, url = url, html_url = html_url, followers_url = followers_url, gists_url = gists_url, repos_url = repos_url, site_admin = site_admin, bio = bio, public_repos = public_repos, followers = followers, following = following, created_at = created_at, updated_at = updated_at, location = location, blog = blog)
+        }
+    }
+}
 
 @Serializable
 data class OwnerData(
@@ -68,7 +74,13 @@ data class OwnerData(
     val repos_url: String,
     @get:JsonProperty("site_admin")
     val site_admin: Boolean
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(id: Int, login: String, url: String, html_url: String, followers_url: String, gists_url: String, repos_url: String, site_admin: Boolean): OwnerData {
+            return OwnerData(id = id, login = login, url = url, html_url = html_url, followers_url = followers_url, gists_url = gists_url, repos_url = repos_url, site_admin = site_admin)
+        }
+    }
+}
 
 @Serializable
 data class OrganizationData(
@@ -84,7 +96,13 @@ data class OrganizationData(
     val repos_url: String,
     @get:JsonProperty("description")
     val description: String?
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(login: String, id: Int, avatar_url: String, repos_url: String, members_url: String? = null, description: String? = null): OrganizationData {
+            return OrganizationData(login = login, id = id, avatar_url = avatar_url, members_url = members_url, repos_url = repos_url, description = description)
+        }
+    }
+}
 
 @Serializable
 @JsonTypeInfo(
@@ -132,7 +150,13 @@ data class Repository(
     val html_url: String,
     @get:JsonProperty("language")
     val language: String?
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(id: Int, name: String, full_name: String, private: Boolean, fork: Boolean, created_at: String, updated_at: String, owner: Owner, url: String, html_url: String, description: String? = null, language: String? = null): Repository {
+            return Repository(id = id, name = name, full_name = full_name, private = private, fork = fork, created_at = created_at, updated_at = updated_at, description = description, owner = owner, url = url, html_url = html_url, language = language)
+        }
+    }
+}
 
 @Serializable
 data class Pusher(
@@ -140,7 +164,13 @@ data class Pusher(
     val name: String,
     @get:JsonProperty("email")
     val email: String
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(name: String, email: String): Pusher {
+            return Pusher(name = name, email = email)
+        }
+    }
+}
 
 @Serializable
 data class Author(
@@ -150,7 +180,13 @@ data class Author(
     val email: String,
     @get:JsonProperty("username")
     val username: String
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(name: String, email: String, username: String): Author {
+            return Author(name = name, email = email, username = username)
+        }
+    }
+}
 
 @Serializable
 data class Label(
@@ -166,7 +202,13 @@ data class Label(
     val default: Boolean,
     @get:JsonProperty("description")
     val description: String
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(id: Int, url: String, name: String, color: String, default: Boolean, description: String): Label {
+            return Label(id = id, url = url, name = name, color = color, default = default, description = description)
+        }
+    }
+}
 
 @Serializable
 data class Issue(
@@ -206,7 +248,13 @@ data class Issue(
     val author_association: String,
     @get:JsonProperty("body")
     val body: String
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(id: Int, url: String, html_url: String, repository_url: String, number: Int, title: String, user: UserData, labels: ArrayList<Label>, state: String, locked: Boolean, assignees: ArrayList<UserData>, comments: Int, created_at: String, updated_at: String, author_association: String, body: String, assignee: UserData? = null, closed_at: String? = null): Issue {
+            return Issue(id = id, url = url, html_url = html_url, repository_url = repository_url, number = number, title = title, user = user, labels = labels, state = state, locked = locked, assignee = assignee, assignees = assignees, comments = comments, created_at = created_at, updated_at = updated_at, closed_at = closed_at, author_association = author_association, body = body)
+        }
+    }
+}
 
 @Serializable
 data class Commit(
@@ -232,7 +280,13 @@ data class Commit(
     val removed: ArrayList<String>,
     @get:JsonProperty("modified")
     val modified: ArrayList<String>
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(id: String, tree_id: String, distinct: Boolean, message: String, timestamp: String, url: String, author: Author, committer: Author, added: ArrayList<String>, removed: ArrayList<String>, modified: ArrayList<String>): Commit {
+            return Commit(id = id, tree_id = tree_id, distinct = distinct, message = message, timestamp = timestamp, url = url, author = author, committer = committer, added = added, removed = removed, modified = modified)
+        }
+    }
+}
 
 @Serializable
 data class PushData(
@@ -262,7 +316,13 @@ data class PushData(
     val commits: ArrayList<Commit>,
     @get:JsonProperty("head_commit")
     val head_commit: Commit
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(repository: Repository, ref: String, before: String, after: String, pusher: Pusher, organization: OrganizationData, sender: UserData, created: Boolean, deleted: Boolean, forced: Boolean, compare: String, commits: ArrayList<Commit>, head_commit: Commit): PushData {
+            return PushData(repository = repository, ref = ref, before = before, after = after, pusher = pusher, organization = organization, sender = sender, created = created, deleted = deleted, forced = forced, compare = compare, commits = commits, head_commit = head_commit)
+        }
+    }
+}
 
 @Serializable
 @JsonTypeInfo(
@@ -286,5 +346,11 @@ data class RepositorySearchData(
     val incomplete_results: Boolean,
     @get:JsonProperty("items")
     val items: ArrayList<Repository>
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(total_count: Int, incomplete_results: Boolean, items: ArrayList<Repository>): RepositorySearchData {
+            return RepositorySearchData(total_count = total_count, incomplete_results = incomplete_results, items = items)
+        }
+    }
+}
 }

--- a/test/reference-output/hasGeneric.kt
+++ b/test/reference-output/hasGeneric.kt
@@ -38,7 +38,13 @@ sealed class Result<T, E> : java.io.Serializable {
 data class Holder<T>(
     @get:JsonProperty("value")
     val value: T
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun <T> create(value: T): Holder<T> {
+            return Holder(value = value)
+        }
+    }
+}
 
 @Serializable
 data class MaybeHolder<T>(
@@ -46,7 +52,13 @@ data class MaybeHolder<T>(
     val value: External_Option<T>,
     @get:JsonProperty("otherValue")
     val otherValue: Other_Plain
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun <T> create(value: External_Option<T>, otherValue: Other_Plain): MaybeHolder<T> {
+            return MaybeHolder(value = value, otherValue = otherValue)
+        }
+    }
+}
 
 @Serializable
 @JsonTypeInfo(

--- a/test/reference-output/importExample.kt
+++ b/test/reference-output/importExample.kt
@@ -20,19 +20,37 @@ data class UsesImport(
     val recruiter: Basic.Recruiter,
     @get:JsonProperty("type")
     val type: String = "UsesImport"
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(recruiter: Basic.Recruiter, type: String = "UsesImport"): UsesImport {
+            return UsesImport(type = type, recruiter = recruiter)
+        }
+    }
+}
 
 @Serializable
 data class HoldsSomething<T>(
     @get:JsonProperty("holdingField")
     val holdingField: T
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun <T> create(holdingField: T): HoldsSomething<T> {
+            return HoldsSomething(holdingField = holdingField)
+        }
+    }
+}
 
 @Serializable
 data class StructureUsingImport(
     @get:JsonProperty("event")
     val event: Basic.Event
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(event: Basic.Event): StructureUsingImport {
+            return StructureUsingImport(event = event)
+        }
+    }
+}
 
 @Serializable
 @JsonTypeInfo(
@@ -58,5 +76,11 @@ sealed class UnionUsingImport : java.io.Serializable {
 data class AllConcrete(
     @get:JsonProperty("field")
     val field: HoldsSomething<Basic.Either<Basic.Maybe<StructureUsingImport>, UnionUsingImport>>
-) : java.io.Serializable
+) : java.io.Serializable {
+    companion object {
+        fun create(field: HoldsSomething<Basic.Either<Basic.Maybe<StructureUsingImport>, UnionUsingImport>>): AllConcrete {
+            return AllConcrete(field = field)
+        }
+    }
+}
 }


### PR DESCRIPTION
This allows us to create an instance of a struct where all the optional fields are automatically set to `null`, without having to poison the original definition with these default values. This means we can use `create` situationally when it makes sense to create an empty version of a struct and then fill in fields as we go, but still enforce fields existing when using the normal constructors (which are otherwise more convenient and direct).